### PR TITLE
feat(bqm): quality-of-life improvements to BinaryQuadraticModel

### DIFF
--- a/ising/typing.py
+++ b/ising/typing.py
@@ -1,0 +1,15 @@
+import enum
+from collections.abc import Hashable
+
+__all__ = ['Variable', 'Bias', 'Vartype']
+
+# Identifier for BQM variables
+Variable = Hashable
+
+# Quadratic, linear and offset bias values (any numeric value which is not complex)
+Bias = int | float
+
+# The variable-type (or encoding) of a BQM
+class Vartype(enum.Enum):
+    SPIN = frozenset({-1, 1}) # False, True
+    BINARY = frozenset({0, 1}) # False, True

--- a/ising/utils/convert.py
+++ b/ising/utils/convert.py
@@ -1,0 +1,105 @@
+from collections.abc import Iterable, Collection, Mapping
+import itertools
+import networkx as nx
+from ising.typing import Variable, Bias
+
+__all__ = [
+    'LinearLike',
+    'convert_to_linear',
+    'QuadraticLike',
+    'convert_to_quadratic',
+    'GraphLike',
+    'convert_to_graph'
+]
+
+LinearLike = Mapping[Variable, Bias] | Iterable[Bias]
+
+def convert_to_linear(thing: LinearLike) -> Mapping[Variable, Bias]:
+
+    # Mapping[Variable, Bias]
+    if isinstance(thing, Mapping):
+        return thing
+
+    # Iterable[Bias]
+    elif isinstance(thing, Iterable):
+        return dict(enumerate(thing))
+
+    else:
+        raise TypeError('Input is not valid for conversion to "linear" argument')
+
+
+QuadraticLike = Mapping[Collection[Variable, Variable], Bias] | \
+                Mapping[Variable, Mapping[Variable, Bias]] | \
+                Iterable[Collection[Variable, Variable, Bias]]
+
+def convert_to_quadratic(thing: QuadraticLike) -> Mapping[Collection[Variable, Variable], Bias]:
+
+    # Mapping[Collection[Variable, Variable], Bias]
+    if isinstance(thing, Mapping) and \
+            all(isinstance(e, Collection) and len(e) == 2 for e in thing.keys()):
+        return thing
+
+    # Mapping[Variable, Mapping[Variable, Bias]]
+    elif isinstance(thing, Mapping) and \
+            all(isinstance(m, Mapping) for m in thing.keys()):
+        quadratic = {}
+        for v, map in thing.items():
+            for u, bias in map.items():
+                quadratic[frozenset({u, v})] = bias
+        return quadratic
+
+    # Iterable[Collection[Variable, Variable, Bias]]
+    elif isinstance(thing, Iterable) and \
+        all(isinstance(e, Collection) and len(e) == 3 for e in thing):
+        return {frozenset({u, v}): b for u, v, b in thing}
+
+    else:
+        raise TypeError('Input is not valid for conversion to "quadratic" argument')
+
+
+GraphLike = int | \
+            Iterable[Variable] | \
+            Iterable[Collection[Variable, Variable]] | \
+            Mapping[Variable, Iterable[Variable]] | \
+            nx.Graph
+
+
+def convert_to_graph(thing: GraphLike) -> tuple[Iterable[Variable], Iterable[Collection[Variable, Variable]]]:
+
+    # int
+    if isinstance(thing, int):
+        nodes = set(range(thing))
+        edges = set(itertools.combinations(range(thing), 2))
+        return nodes, edges
+
+    # NetworkX graph
+    elif isinstance(thing, nx.Graph):
+        return list(thing.node), list(thing.edges)
+
+    # mapping[Variable, Iterable[Variable]]
+    elif isinstance(thing, Mapping) and \
+        all(isinstance(m, Mapping) for m in thing.keys()):
+        nodes = set()
+        edges = set()
+        for v, adj in thing.items():
+            nodes.add(v)
+            for u in adj:
+                nodes.add(u)
+                edges.add(frozenset({u, v}))
+        return nodes, edges
+
+    # Iterable[Collection[Variable, Variable]]
+    elif isinstance(thing, Iterable) and \
+        all(isinstance(e, Collection) and len(e) == 2 for e in thing):
+        nodes = set(itertools.chain(*thing))
+        edges = set(thing)
+        return nodes, edges
+
+    # Iterable[Variable]
+    elif isinstance(thing, Iterable):
+        nodes = set(thing)
+        edges = set(itertools.combinations(thing, 2))
+        return nodes, edges
+
+    else:
+        raise TypeError('Input is not valid for conversion to "graph" argument')

--- a/ising/utils/numpy.py
+++ b/ising/utils/numpy.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+__all__ = ['triu_to_symm']
+
+
+def triu_to_symm(M: np.ndarray):
+    M[np.tril_indices_from(M, k=-1)] = np.triu(M, k=1)


### PR DESCRIPTION
- LinearLike and QuadraticLike broaden the input possibilities of a BinaryQuadraticModel. For converting from this general types to proper input types, the conver-utility was made.
- add shape property
- move typing to ising/typing.py.
- add numpy utility for dealing with triangular to symmetric matrices.